### PR TITLE
chore: add dependabot grouping for WBT, update refs to v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
     groups:
       wow-build-tools:
         patterns:
-          - "McTalian/wow-build-tools*"
-          - "McTalian-WoW-Addons/wow-build-tools*"
+          - McTalian/wow-build-tools*
+          - McTalian-WoW-Addons/wow-build-tools*
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      wow-build-tools:
+        patterns:
+          - "McTalian/wow-build-tools*"
+          - "McTalian-WoW-Addons/wow-build-tools*"
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/.github/workflows/cleanup-stale-issues.yml
+++ b/.github/workflows/cleanup-stale-issues.yml
@@ -11,4 +11,4 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/cleanup-stale-issues.yml@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       actions: write
       pull-requests: write
       issues: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/ci.yml@v1
     with:
       addon-name: BeaconUnitFrames
       rockspec-name: buf-1-1.rockspec

--- a/.github/workflows/package-and-distribute.yml
+++ b/.github/workflows/package-and-distribute.yml
@@ -11,7 +11,7 @@ jobs:
   package-and-release:
     permissions:
       contents: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/package-and-distribute.yml@v1
     with:
       addon-name: BeaconUnitFrames
       avatar-url: https://raw.githubusercontent.com/McTalian-WoW-Addons/BeaconUnitFrames/main/BeaconUnitFrames/icons/logo.png

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,11 +17,11 @@ jobs:
       actions: write
       pull-requests: write
       checks: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/pr-checks.yml@v1
     with:
       addon-name: BeaconUnitFrames
       rockspec-name: buf-1-1.rockspec
       i18n-enabled: true
       trunk-enabled: true
-      wbt-ref: v1-beta
+      wbt-ref: v1
     secrets: inherit

--- a/.github/workflows/toc-updater.yml
+++ b/.github/workflows/toc-updater.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1-beta
+    uses: McTalian-WoW-Addons/wow-build-tools/.github/workflows/toc-updater.yml@v1
     with:
       addon-name: BeaconUnitFrames
       pr-body: |


### PR DESCRIPTION
- Groups all `McTalian/wow-build-tools*` and `McTalian-WoW-Addons/wow-build-tools*` dependencies into a single Dependabot PR (instead of one per reusable workflow)
- Updates `@v1-beta` → `@v1` across all workflow files
- Updates `wbt-ref: v1-beta` → `wbt-ref: v1`