### PR TITLE
chore: bump wbt-configs to v0.1.2, drop redundant ignores

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,19 +10,8 @@ plugins:
       ref: v1.10.2
       uri: https://github.com/trunk-io/plugins
     - id: wbt-configs
-      ref: v0.1.1
+      ref: v0.1.2
       uri: https://github.com/McTalian-WoW-Addons/wow-addon-trunk-configs
-lint:
-  ignore:
-    - linters: [markdownlint]
-      paths:
-        - .github/docs/**
-        - .github/instructions/**
-        - .github/prompts/**
-        - .github/copilot-instructions.md
-    - linters: [stylua]
-      paths:
-        - "**/locale/*"
 actions:
   enabled:
     - trunk-announce


### PR DESCRIPTION
Bumps shared trunk plugin ref to v0.1.2. Drops ignore patterns now managed centrally by the plugin.